### PR TITLE
fix: escape curly braces in abstract for BibTeX compatibility

### DIFF
--- a/arxivcollector.py
+++ b/arxivcollector.py
@@ -60,7 +60,7 @@ class ArXivCollector():
 
     def extract_text(self, soup: BeautifulSoup, selector):
         try:
-            text = soup.select_one(selector).getText(strip=True)
+            text = ' '.join(soup.select_one(selector).getText().split())
         except AttributeError:
             text = None
         return text

--- a/arxivcollector.py
+++ b/arxivcollector.py
@@ -93,7 +93,7 @@ class ArXivCollector():
 
             abstract_text = self.extract_text(li, 'span.abstract-full')
             if abstract_text:
-                Abstract = abstract_text[:-len('△ Less')]
+                Abstract = abstract_text[:-len('△ Less')].replace('{', r'\{').replace('}', r'\}')
             else:
                 Abstract = ''
 


### PR DESCRIPTION
## Summary
- Escape `{` and `}` characters in abstract text to prevent BibTeX parser errors
- Fixes issue where abstracts containing curly braces cause Zotero import failures

## Problem
When an abstract contains `{` or `}` characters (e.g., `(the "there"} in our title)`), BibTeX parsers misinterpret them as field delimiters, resulting in:
- Truncated abstract content
- Empty entries in reference managers like Zotero
- Missing metadata (title, author) for affected entries

## Solution
Added `.replace('{', r'\{').replace('}', r'\}')` to escape curly braces in abstract text before BibTeX output.

## Testing
Tested with arXiv paper "There and Back Again: A Netlist's Tale with Much Egraphin'" which contains `}` in abstract. After fix, Zotero correctly imports all entries without empty records.

```
python3 arxivcollector.py "https://arxiv.org/search/?query=There+and+Back+Again%3A+A+Netlist%27s+Tale+with+Much+Egraphin%27&searchtype=all&source=header" "test_escape" "bibtex"
```